### PR TITLE
Switch permission to use TreeConnect.MaximalAccess

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Austin Ralls
+Copyright (c) 2021-2022 Austin Ralls
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,64 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+The connectTree function in smbls/__init__.by is modified from Impacket, which
+is available under the following license:
+
+We provide this software under a slightly modified version of the
+Apache Software License. The only changes to the document were the
+replacement of "Apache" with "Impacket" and "Apache Software Foundation"
+with "SecureAuth Corporation". Feel free to compare the resulting
+document to the official Apache license.
+
+The `Apache Software License' is an Open Source Initiative Approved
+License.
+
+
+The Apache Software License, Version 1.1
+Modifications by SecureAuth Corporation (see above)
+
+Copyright (c) 2000 The Apache Software Foundation.  All rights
+reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:
+      "This product includes software developed by
+       SecureAuth Corporation (https://www.secureauth.com/)."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "Impacket", "SecureAuth Corporation" must
+   not be used to endorse or promote products derived from this
+   software without prior written permission. For written
+   permission, please contact oss@secureauth.com.
+
+5. Products derived from this software may not be called "Impacket",
+   nor may "Impacket" appear in their name, without prior written
+   permission of SecureAuth Corporation.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
+ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = smbls
-version = 1.1.0
+version = 2.0.0-rc
 description = list SMB shares
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/smbls/__init__.py
+++ b/smbls/__init__.py
@@ -1,17 +1,31 @@
 #!/usr/bin/env python3
 
 import argparse
+import copy
 import json
 import re
+import socket
+import traceback
 from enum import IntFlag
 from multiprocessing import Pool
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+from impacket import smb3, smbconnection
 from impacket.dcerpc.v5 import srvs
-from impacket.smbconnection import SessionError, SMBConnection
 from impacket.nmb import NetBIOSTimeout
-
+from impacket.nt_errors import STATUS_SUCCESS
+from impacket.smb3structs import (
+    SMB2_DIALECT_30,
+    SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY,
+    SMB2_SHARE_CAP_DFS,
+    SMB2_SHARE_CAP_SCALEOUT,
+    SMB2_SHAREFLAG_ENCRYPT_DATA,
+    SMB2_TREE_CONNECT,
+    SMB2TreeConnect,
+    SMB2TreeConnect_Response,
+)
+from impacket.smbconnection import SessionError, SMBConnection
 
 # Max time in seconds for each impacket SMB request
 REQUEST_TIMEOUT = 5
@@ -40,6 +54,34 @@ class STypes(IntFlag):
     TEMPORARY = srvs.STYPE_TEMPORARY
 
 
+class MaximalAccessFlags(IntFlag):
+    """Directory access flags
+
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0a5934b1-80f1-4da0-b1bf-5e021c309b71
+    """
+
+    FILE_LIST_DIRECTORY = 0x00000001
+    FILE_ADD_FILE = 0x00000002
+    FILE_ADD_SUBDIRECTORY = 0x00000004
+    FILE_READ_EA = 0x00000008
+    FILE_WRITE_EA = 0x00000010
+    FILE_TRAVERSE = 0x00000020
+    FILE_DELETE_CHILD = 0x00000040
+    FILE_READ_ATTRIBUTES = 0x00000080
+    FILE_WRITE_ATTRIBUTES = 0x00000100
+    DELETE = 0x00010000
+    READ_CONTROL = 0x00020000
+    WRITE_DAC = 0x00040000
+    WRITE_OWNER = 0x00080000
+    SYNCHRONIZE = 0x00100000
+    ACCESS_SYSTEM_SECURITY = 0x01000000
+    MAXIMUM_ALLOWED = 0x02000000
+    GENERIC_ALL = 0x10000000
+    GENERIC_EXECUTE = 0x20000000
+    GENERIC_WRITE = 0x40000000
+    GENERIC_READ = 0x80000000
+
+
 def list_shares_multicred(
     argbundle: Tuple[List[Creds], str]
 ) -> Tuple[str, Dict[str, Scan]]:
@@ -60,6 +102,79 @@ def list_shares_multicred(
     return host, res
 
 
+def connectTree(self: SMBConnection, share: str) -> Tuple[int, int]:
+    """
+    Modified SMBConnection.connectTree that returns MaximalAccess parameter.
+
+    Changes:
+    - Return (TreeID, MaximalAccess)
+    - Raise Exception on error
+    - Allow connecting to already-connected share because
+      SMBConnection.listShares already connects to IPC$ once
+    - Format with Black
+
+    The first change is the only functionally important one. In the future I
+    hope this data is exposed by Impacket and this function can be removed.
+
+    Original source:
+    https://github.com/SecureAuthCorp/impacket/blob/cd4fe47cfcb72d7d35237a99e3df95cedf96e94f/impacket/smb3.py#L1065
+    """
+    share = share.split("\\")[-1]
+    try:
+        _, _, _, _, sockaddr = socket.getaddrinfo(
+            self._Connection["ServerIP"], 80, 0, 0, socket.IPPROTO_TCP
+        )[0]
+        remoteHost = sockaddr[0]
+    except Exception:
+        remoteHost = self._Connection["ServerIP"]
+    path = "\\\\" + remoteHost + "\\" + share
+    treeConnect = SMB2TreeConnect()
+    treeConnect["Buffer"] = path.encode("utf-16le")
+    treeConnect["PathLength"] = len(path) * 2
+
+    packet = self.SMB_PACKET()
+    packet["Command"] = SMB2_TREE_CONNECT
+    packet["Data"] = treeConnect
+    packetID = self.sendSMB(packet)
+    packet = self.recvSMB(packetID)
+    if not packet.isValidAnswer(STATUS_SUCCESS):
+        raise Exception("TreeConnect call failed")
+    treeConnectResponse = SMB2TreeConnect_Response(packet["Data"])
+    treeEntry = copy.deepcopy(smb3.TREE_CONNECT)
+    treeEntry["ShareName"] = share
+    treeEntry["TreeConnectId"] = packet["TreeID"]
+    treeEntry["Session"] = packet["SessionID"]
+    treeEntry["NumberOfUses"] += 1
+    if (treeConnectResponse["Capabilities"] & SMB2_SHARE_CAP_DFS) == SMB2_SHARE_CAP_DFS:
+        treeEntry["IsDfsShare"] = True
+    if (
+        treeConnectResponse["Capabilities"] & SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY
+    ) == SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY:
+        treeEntry["IsCAShare"] = True
+
+    if self._Connection["Dialect"] >= SMB2_DIALECT_30:
+        if (self._Connection["SupportsEncryption"] is True) and (
+            (treeConnectResponse["ShareFlags"] & SMB2_SHAREFLAG_ENCRYPT_DATA)
+            == SMB2_SHAREFLAG_ENCRYPT_DATA
+        ):
+            treeEntry["EncryptData"] = True
+            # ToDo: This and what follows
+            # If Session.EncryptData is FALSE, the client MUST then generate an encryption key, a
+            # decryption key as specified in section 3.1.4.2, by providing the following inputs and store
+            # them in Session.EncryptionKey and Session.DecryptionKey:
+        if (
+            treeConnectResponse["Capabilities"] & SMB2_SHARE_CAP_SCALEOUT
+        ) == SMB2_SHARE_CAP_SCALEOUT:
+            treeEntry["IsScaleoutShare"] = True
+
+    self._Session["TreeConnectTable"][packet["TreeID"]] = treeEntry
+    self._Session["TreeConnectTable"][share] = treeEntry
+    return (
+        packet["TreeID"],
+        treeConnectResponse["MaximalAccess"],
+    )
+
+
 def list_shares(creds: Creds, host: str) -> Scan:
     try:
         smbconn = SMBConnection(host, host, timeout=REQUEST_TIMEOUT)
@@ -73,7 +188,7 @@ def list_shares(creds: Creds, host: str) -> Scan:
 
     except OSError as e:
         return {"errtype": "conn", "error": str(e.strerror)}
-    except SessionError as e:
+    except smbconnection.SessionError as e:
         return {"errtype": "auth", "error": str(e)}
     except NetBIOSTimeout:
         return {"errtype": "timeout", "error": "timed out logging in"}
@@ -109,12 +224,29 @@ def list_shares(creds: Creds, host: str) -> Scan:
             for share in smbconn.listShares():
                 share_name = share["shi1_netname"][:-1]
                 try:
-                    smbconn.listPath(share_name, "*")
-                    access = "READ"
-                    access_error = ""
-                except SessionError as e:
+                    treeID, access_raw = connectTree(smbconn._SMBConnection, share_name)
+                    try:
+                        if smbconn._SMBConnection.disconnectTree(treeID):
+                            access_error = ""
+                        else:
+                            access_error = "TreeDisconnect call failed"
+                    except Exception as e:
+                        access_error = (
+                            f"TreeDisconnect call failed: {e}\n{traceback.format_exc()}"
+                        )
+                    access = (
+                        str(MaximalAccessFlags(access_raw))
+                        .removeprefix("MaximalAccessFlags.")
+                        .removeprefix("0")
+                    )
+                except smb3.SessionError as e:
                     access_error = str(e)
                     access = ""
+                    access_raw = 0
+                except Exception:
+                    access_error = traceback.format_exc()
+                    access = ""
+                    access_raw = 0
                 if (share_name == "C$" or share_name == "ADMIN$") and access:
                     admin = True
                 shares.append(
@@ -135,6 +267,7 @@ def list_shares(creds: Creds, host: str) -> Scan:
                         "remark": share["shi1_remark"][:-1],
                         "access": access,
                         "access_error": access_error,
+                        "access_raw": access_raw,
                     }
                 )
         except Exception as e:
@@ -148,7 +281,7 @@ def list_shares(creds: Creds, host: str) -> Scan:
             "admin": admin,
         }
     except Exception as e:
-        return {"errtype": "unknown", "error": str(type(e)) + str(e)}
+        return {"errtype": "unknown", "error": str(e)}
     finally:
         smbconn.close()
 
@@ -262,8 +395,8 @@ $ smbls -C creds.txt targets.txt -O example_dir
             except Exception as e:
                 # If you see this, please file an issue
                 print(
-                    f"Error in main loop: '{e}'\n"
-                    "writing partial output and exiting..."
+                    f"{traceback.format_exc()}'\n"
+                    f"Error in main loop. Writing partial output and exiting."
                 )
                 loop_e = e
                 break

--- a/smbls/__init__.py
+++ b/smbls/__init__.py
@@ -386,7 +386,7 @@ $ smbls -C creds.txt targets.txt -O example_dir
                 # list_shares sends 3 requests, so allow each of them to almost
                 # time out plus a buffer second. This timeout should never
                 # trigger unless there's a bug somewhere.
-                host, res = it.next(timeout=REQUEST_TIMEOUT * 3 + 1)
+                host, res = it.next(timeout=REQUEST_TIMEOUT * 3 * len(creds_list) + 1)
                 for serialized_creds, scan in res.items():
                     scan_res[serialized_creds][host] = scan
                     print(


### PR DESCRIPTION
Previously share permissions would be binary READ or none and there was
no testing for write permissions. This was done by calling
`SMBConnection.listPath` for each share and seeing if there was an
error. Now, share permissions come from Sending a TreeConnect packet for
each share and reporting the returned MaximalAccess bitmask.

There are some disadvantages to this:
- Might not work with SMBv1.
- Gives false positives when a share has permissions but the root folder
  has no permissions.
- This code is not well tested.

But also major advantages:
- Reports granular permissions including write access.
- Sends fewer packets and should be faster.

This is a testing commit.